### PR TITLE
feature: Possible solution of preloading schemas

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -21,4 +21,4 @@ rules:
     - all
   no-unused-vars:
     - error
-    - argsIgnorePattern: '^_'
+    - varsIgnorePattern: '^_'

--- a/lib/schema-configuration/index.ts
+++ b/lib/schema-configuration/index.ts
@@ -1,0 +1,3 @@
+export * from './schema-enum';
+export * from './schema-precompiler';
+export * from './schema-registration';

--- a/lib/schema-configuration/schema-enum.ts
+++ b/lib/schema-configuration/schema-enum.ts
@@ -1,0 +1,3 @@
+export enum PrecompiledSchemas {
+  _catDto,
+}

--- a/lib/schema-configuration/schema-precompiler.ts
+++ b/lib/schema-configuration/schema-precompiler.ts
@@ -1,0 +1,34 @@
+import { AjvValidator } from '../../lib';
+import { PrecompiledSchemas } from './schema-enum';
+
+export class SchemaPrecompiler {
+  private static instance: SchemaPrecompiler;
+  private validators: object;
+  private ajvValidator: AjvValidator;
+
+  private constructor() {
+    this.ajvValidator = new AjvValidator({
+      allErrors: true,
+      useDefaults: true,
+    });
+    this.validators = new Object();
+  }
+
+  public static getInstance(): SchemaPrecompiler {
+    if (!SchemaPrecompiler.instance) {
+      SchemaPrecompiler.instance = new SchemaPrecompiler();
+    }
+
+    return SchemaPrecompiler.instance;
+  }
+
+  public precompileSchema(schema: Object, key: PrecompiledSchemas): void {
+    const schemaWithAsync = (schema.valueOf()['$async'] = true);
+    const validator = this.ajvValidator.ajv.compile(schemaWithAsync);
+    this.validators[key] = validator;
+  }
+
+  public getValidatorByKey(key: PrecompiledSchemas): any {
+    return this.validators[key];
+  }
+}

--- a/lib/schema-configuration/schema-registration.ts
+++ b/lib/schema-configuration/schema-registration.ts
@@ -1,0 +1,10 @@
+import { SchemaPrecompiler } from './schema-precompiler';
+import { catDto } from './test-schemas/cats.schemas';
+import { PrecompiledSchemas } from './schema-enum';
+
+export class SchemaRegistration {
+  public static Init(): void {
+    const precompiler = SchemaPrecompiler.getInstance();
+    precompiler.precompileSchema(catDto.valueOf(), PrecompiledSchemas._catDto);
+  }
+}

--- a/lib/schema-configuration/test-schemas/cats.schemas.ts
+++ b/lib/schema-configuration/test-schemas/cats.schemas.ts
@@ -1,0 +1,12 @@
+import S from 'fluent-json-schema';
+import { userDto } from './user.schemas';
+import { createRef } from '../../../lib';
+
+export const catDto = S.object()
+  .additionalProperties(false)
+  .prop('name', S.string())
+  .prop('age', S.number())
+  .prop(
+    'user',
+    createRef(() => userDto),
+  );

--- a/lib/schema-configuration/test-schemas/user.schemas.ts
+++ b/lib/schema-configuration/test-schemas/user.schemas.ts
@@ -1,0 +1,12 @@
+import S from 'fluent-json-schema';
+import { catDto } from './cats.schemas';
+import { createRef } from '../../../lib';
+
+export const userDto = S.object()
+  .additionalProperties(false)
+  .prop('firstName', S.string())
+  .prop('lastName', S.string())
+  .prop(
+    'cat',
+    createRef(() => catDto),
+  );

--- a/test/schema-precompiler.spec.ts
+++ b/test/schema-precompiler.spec.ts
@@ -1,0 +1,36 @@
+import { SchemaRegistration } from '../lib/schema-configuration/schema-registration';
+import { SchemaPrecompiler } from '../lib/schema-configuration/schema-precompiler';
+import * as chai from 'chai';
+import { PrecompiledSchemas } from '../lib/schema-configuration/schema-enum';
+
+const expect = chai.expect;
+
+describe('SchemaPrecompiler', () => {
+  SchemaRegistration.Init();
+  it('should validate plain object with schema with circular dependencies', async () => {
+    const data = {
+      name: 'name1',
+      age: 5,
+    };
+    const validate = SchemaPrecompiler.getInstance().getValidatorByKey(
+      PrecompiledSchemas._catDto,
+    );
+    const valid = validate(data);
+    expect(valid).to.equal(true);
+  });
+  it('should validate circular object schema with circular dependencies', async () => {
+    const data = {
+      name: 'name1',
+      age: 5,
+      user: {
+        firstName: 'firstName1',
+        lastname: 'lastname1',
+      },
+    };
+    const validate = SchemaPrecompiler.getInstance().getValidatorByKey(
+      PrecompiledSchemas._catDto,
+    );
+    const valid = validate(data);
+    expect(valid).to.equal(true);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Refactoring an existing  ajv-validator wrapper could not lead to some schema preloading, because instance of ajv-validator is always created when data has to be processed. Schemas can be preprocessed by registering them in advance, as it is done by different DI tools. Solution is done by using singlton precompiler class, that will provide premade validators and static class for schemas registration using simple enum.

Issue Number: 35


## What is the new behavior?
Data validation will be done using not the ajv-validator, but using SchemaPrecompiler, that will provide premade validators by enum key

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
